### PR TITLE
Added NPC Dialog to purchasing buildings

### DIFF
--- a/buildings/variations/apartment.tres
+++ b/buildings/variations/apartment.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" script_class="BuildingVariation" load_steps=4 format=3 uid="uid://blctvydks2h24"]
+[gd_resource type="Resource" script_class="BuildingVariation" load_steps=5 format=3 uid="uid://blctvydks2h24"]
 
 [ext_resource type="Script" path="res://scripts/systems/building_grid/building_variation.gd" id="1_3jvir"]
 [ext_resource type="Resource" uid="uid://bh0s6jhfgvuwv" path="res://buildings/apartment.tres" id="1_11ynu"]
+[ext_resource type="Texture2D" uid="uid://cgpcvb844wi6" path="res://sprites/test/icon.svg" id="1_s3bq5"]
 [ext_resource type="Texture2D" uid="uid://b4wejql45gxc2" path="res://sprites/buildings/apartments.png" id="3_pbyl4"]
 
 [resource]
@@ -9,3 +10,6 @@ script = ExtResource("1_3jvir")
 sprite = ExtResource("3_pbyl4")
 building_name = "Apartment"
 blueprint = ExtResource("1_11ynu")
+NPCDialog = Array[String](["This is a apartment", "I' selling it to you"])
+NPCImage = ExtResource("1_s3bq5")
+NPCName = "Apartment"

--- a/buildings/variations/cafe.tres
+++ b/buildings/variations/cafe.tres
@@ -1,6 +1,7 @@
-[gd_resource type="Resource" script_class="BuildingVariation" load_steps=4 format=3 uid="uid://be6stuus2km8m"]
+[gd_resource type="Resource" script_class="BuildingVariation" load_steps=5 format=3 uid="uid://be6stuus2km8m"]
 
 [ext_resource type="Resource" uid="uid://o4wnmgkxop7d" path="res://buildings/cafe.tres" id="1_64t5p"]
+[ext_resource type="Texture2D" uid="uid://cgpcvb844wi6" path="res://sprites/test/icon.svg" id="1_wq4ui"]
 [ext_resource type="Script" path="res://scripts/systems/building_grid/building_variation.gd" id="2_pja3x"]
 [ext_resource type="Texture2D" uid="uid://3luu62vikwou" path="res://sprites/buildings/cafe.png" id="3_dujgj"]
 
@@ -9,3 +10,6 @@ script = ExtResource("2_pja3x")
 sprite = ExtResource("3_dujgj")
 building_name = "Café"
 blueprint = ExtResource("1_64t5p")
+NPCDialog = Array[String](["I'm selling you a cafe", "These messages are picked at ranodm"])
+NPCImage = ExtResource("1_wq4ui")
+NPCName = "Cafe"

--- a/buildings/variations/city_hall.tres
+++ b/buildings/variations/city_hall.tres
@@ -1,5 +1,6 @@
-[gd_resource type="Resource" script_class="BuildingVariation" load_steps=4 format=3 uid="uid://bas3a8n65ds1"]
+[gd_resource type="Resource" script_class="BuildingVariation" load_steps=5 format=3 uid="uid://bas3a8n65ds1"]
 
+[ext_resource type="Texture2D" uid="uid://cgpcvb844wi6" path="res://sprites/test/icon.svg" id="1_025ft"]
 [ext_resource type="Resource" uid="uid://cbd8qt7xqw4v1" path="res://buildings/city_hall.tres" id="1_wiphg"]
 [ext_resource type="Script" path="res://scripts/systems/building_grid/building_variation.gd" id="2_5pm6u"]
 [ext_resource type="Texture2D" uid="uid://blrtmwevytseb" path="res://sprites/buildings/cityHall.png" id="3_yiuo5"]
@@ -9,3 +10,6 @@ script = ExtResource("2_5pm6u")
 sprite = ExtResource("3_yiuo5")
 building_name = "City Hall"
 blueprint = ExtResource("1_wiphg")
+NPCDialog = Array[String](["WOW, THIS IS A CITY HALL", "Please buy it I wil be very sad. It's free after all"])
+NPCImage = ExtResource("1_025ft")
+NPCName = "City Hall"

--- a/buildings/variations/nuclear_reactor.tres
+++ b/buildings/variations/nuclear_reactor.tres
@@ -1,5 +1,6 @@
-[gd_resource type="Resource" script_class="BuildingVariation" load_steps=4 format=3 uid="uid://dutfrehwacddo"]
+[gd_resource type="Resource" script_class="BuildingVariation" load_steps=5 format=3 uid="uid://dutfrehwacddo"]
 
+[ext_resource type="Texture2D" uid="uid://cgpcvb844wi6" path="res://sprites/test/icon.svg" id="1_o7gb0"]
 [ext_resource type="Resource" uid="uid://da5icvnicvami" path="res://buildings/nuclear_reactor.tres" id="1_xlphn"]
 [ext_resource type="Script" path="res://scripts/systems/building_grid/building_variation.gd" id="2_sex6l"]
 [ext_resource type="Texture2D" uid="uid://bdsrb7og8piqf" path="res://sprites/buildings/nuclear_reactor.png" id="3_a6n15"]
@@ -9,3 +10,6 @@ script = ExtResource("2_sex6l")
 sprite = ExtResource("3_a6n15")
 building_name = "Nuclear Reactor"
 blueprint = ExtResource("1_xlphn")
+NPCDialog = Array[String](["This is a nuclear reactor", "you should buy this since it wins you the game"])
+NPCImage = ExtResource("1_o7gb0")
+NPCName = "Nuclear Reactor"

--- a/buildings/variations/park.tres
+++ b/buildings/variations/park.tres
@@ -1,5 +1,6 @@
-[gd_resource type="Resource" script_class="BuildingVariation" load_steps=4 format=3 uid="uid://bsegeoaejh2yl"]
+[gd_resource type="Resource" script_class="BuildingVariation" load_steps=5 format=3 uid="uid://bsegeoaejh2yl"]
 
+[ext_resource type="Texture2D" uid="uid://cgpcvb844wi6" path="res://sprites/test/icon.svg" id="1_4i4ra"]
 [ext_resource type="Resource" uid="uid://cfyagiutao5c2" path="res://buildings/park.tres" id="1_fhtr8"]
 [ext_resource type="Script" path="res://scripts/systems/building_grid/building_variation.gd" id="2_1tkkh"]
 [ext_resource type="Texture2D" uid="uid://c8v46qs671x27" path="res://sprites/buildings/park.png" id="3_l7xma"]
@@ -9,3 +10,6 @@ script = ExtResource("2_1tkkh")
 sprite = ExtResource("3_l7xma")
 building_name = "Park"
 blueprint = ExtResource("1_fhtr8")
+NPCDialog = Array[String](["This is a park", "Very useful. Probably the best building in the game"])
+NPCImage = ExtResource("1_4i4ra")
+NPCName = "Park"

--- a/buildings/variations/school.tres
+++ b/buildings/variations/school.tres
@@ -1,5 +1,6 @@
-[gd_resource type="Resource" script_class="BuildingVariation" load_steps=4 format=3 uid="uid://65ueslr70uo"]
+[gd_resource type="Resource" script_class="BuildingVariation" load_steps=5 format=3 uid="uid://65ueslr70uo"]
 
+[ext_resource type="Texture2D" uid="uid://cgpcvb844wi6" path="res://sprites/test/icon.svg" id="1_8b16h"]
 [ext_resource type="Resource" uid="uid://du6t0xow0k5db" path="res://buildings/school.tres" id="1_ghnt4"]
 [ext_resource type="Script" path="res://scripts/systems/building_grid/building_variation.gd" id="2_6rxls"]
 [ext_resource type="Texture2D" uid="uid://bwkstq2h01f78" path="res://sprites/buildings/school.png" id="3_6c7c4"]
@@ -9,3 +10,6 @@ script = ExtResource("2_6rxls")
 sprite = ExtResource("3_6c7c4")
 building_name = "School"
 blueprint = ExtResource("1_ghnt4")
+NPCDialog = Array[String](["This is a school", "It's a institution of learning and irnociallym, you want to buy it in the late game"])
+NPCImage = ExtResource("1_8b16h")
+NPCName = "School"

--- a/buildings/variations/solar_farm.tres
+++ b/buildings/variations/solar_farm.tres
@@ -1,6 +1,7 @@
-[gd_resource type="Resource" script_class="BuildingVariation" load_steps=4 format=3 uid="uid://bhxuoe0d6x3u1"]
+[gd_resource type="Resource" script_class="BuildingVariation" load_steps=5 format=3 uid="uid://bhxuoe0d6x3u1"]
 
 [ext_resource type="Resource" uid="uid://x7obthv6pdcy" path="res://buildings/solar_farm.tres" id="1_j4nx5"]
+[ext_resource type="Texture2D" uid="uid://cgpcvb844wi6" path="res://sprites/test/icon.svg" id="1_mqd7h"]
 [ext_resource type="Script" path="res://scripts/systems/building_grid/building_variation.gd" id="2_0mg7q"]
 [ext_resource type="Texture2D" uid="uid://c2ti2vov3or7t" path="res://sprites/buildings/solar_farm.png" id="3_awn1x"]
 
@@ -9,3 +10,6 @@ script = ExtResource("2_0mg7q")
 sprite = ExtResource("3_awn1x")
 building_name = "Solar Farm"
 blueprint = ExtResource("1_j4nx5")
+NPCDialog = Array[String](["This is a solar farm", "These are very powerful and you should get a few. Clean energy is great afterall"])
+NPCImage = ExtResource("1_mqd7h")
+NPCName = "Solar Farm"

--- a/scenes/ui/npc_dialogue_box.tscn
+++ b/scenes/ui/npc_dialogue_box.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://bq56tb6w0hcbb"]
+[gd_scene load_steps=7 format=3 uid="uid://bq56tb6w0hcbb"]
 
 [ext_resource type="Script" path="res://scripts/ui/gameplay/npc_dialogue_box.gd" id="1_mteuw"]
 [ext_resource type="Texture2D" uid="uid://vfgrp5seiq7s" path="res://sprites/ui/dialogue_nine_patch.png" id="2_l5pa6"]
 [ext_resource type="Theme" uid="uid://babe0j67pdkhx" path="res://theming/hud.tres" id="3_d7jb6"]
 [ext_resource type="Texture2D" uid="uid://civju8sthute2" path="res://sprites/ui/dialogue button.png" id="4_17q0w"]
 [ext_resource type="LabelSettings" uid="uid://dyeel2yw3srlj" path="res://theming/button_label.tres" id="5_pxven"]
+[ext_resource type="Texture2D" uid="uid://cgpcvb844wi6" path="res://sprites/test/icon.svg" id="6_8ifu1"]
 
 [node name="NpcDialogueBox" type="Control"]
 layout_mode = 3
@@ -25,6 +26,35 @@ patch_margin_top = 13
 patch_margin_right = 13
 patch_margin_bottom = 13
 
+[node name="NPCName" type="NinePatchRect" parent="NinePatchRect"]
+offset_top = -13.0
+offset_right = 122.0
+offset_bottom = 24.0
+texture = ExtResource("2_l5pa6")
+region_rect = Rect2(0, 0, 39, 39)
+patch_margin_left = 13
+patch_margin_top = 13
+patch_margin_right = 13
+patch_margin_bottom = 13
+
+[node name="NameLabel" type="RichTextLabel" parent="NinePatchRect/NPCName"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 11.0
+offset_top = 19.0
+offset_right = -9.0
+offset_bottom = -20.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("3_d7jb6")
+bbcode_enabled = true
+text = "GoDot"
+fit_content = true
+scroll_active = false
+shortcut_keys_enabled = false
+
 [node name="RichTextLabel" type="RichTextLabel" parent="NinePatchRect"]
 layout_mode = 1
 anchors_preset = 15
@@ -32,7 +62,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 13.0
 offset_top = 13.0
-offset_right = -13.0
+offset_right = -14.0
 offset_bottom = -53.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -109,3 +139,12 @@ label_settings = ExtResource("5_pxven")
 horizontal_alignment = 1
 vertical_alignment = 1
 autowrap_mode = 3
+
+[node name="TextureRect" type="TextureRect" parent="NinePatchRect"]
+layout_mode = 0
+offset_left = -29.0
+offset_top = 19.0
+offset_right = 41.0
+offset_bottom = 89.0
+texture = ExtResource("6_8ifu1")
+expand_mode = 2

--- a/scripts/systems/building_grid/building_variation.gd
+++ b/scripts/systems/building_grid/building_variation.gd
@@ -12,3 +12,12 @@ extends Resource
 
 ## The blueprint on which this variation is based.
 @export var blueprint: BuildingBlueprint
+
+# the possible dialog the associated NPC will say when the building is insepcted
+@export var NPCDialog: Array[String]
+
+# the image associated with the building's NPC
+@export var NPCImage: Texture2D
+
+# the name of the building's NPC
+@export var NPCName: String

--- a/scripts/ui/gameplay/npc_dialogue_box.gd
+++ b/scripts/ui/gameplay/npc_dialogue_box.gd
@@ -12,6 +12,9 @@ var variation: BuildingVariation
 ## The price of this building in coins
 var price: int
 
+## the label setting which turns the button red 
+var label_setting_red: LabelSettings
+
 ## The button to ignore the interaction.
 @onready var no_button: TextureButton = $NinePatchRect/NoButton
 
@@ -20,7 +23,12 @@ var price: int
 
 @onready var yes_button_text: Label = $NinePatchRect/YesButton/Label
 
-var label_setting_red: LabelSettings
+#text which displays the NPC's name
+@onready var NPCLabel: RichTextLabel = $NinePatchRect/NPCName/NameLabel
+
+#Texture rectangle which displays the mugshot of the NPC
+@onready var NPCPicture: TextureRect = $NinePatchRect/TextureRect
+
 
 ## Initialize this dialogue box's values from a specific balloon.
 func init_from_balloon(balloon, canAfford):
@@ -39,11 +47,19 @@ func _ready() -> void:
 
 func update_text() -> void:
 	resize_borders(Vector2(320, 300))
+	var randomIndex = randi() % variation.NPCDialog.size()
+	NPCPicture.texture = variation.NPCImage
+	NPCLabel.text = variation.NPCName
 	set_text_no_resize(
-"%s
+"
+[indent][indent]%s[/indent][/indent]
+
+
+
+%s
 %s
 Cost: %d coins"
-		% [variation.building_name, variation.blueprint.description, price])
+		% [variation.NPCDialog[randomIndex], variation.building_name, variation.blueprint.description, price])
 
 ## Called when clicking the "buy" button
 signal buy()


### PR DESCRIPTION
Added a TextureRect, NPCName, and NPC dialog to the npc_dialogue_box. Edited the building_variation.gd to include NPCName, NPCDialog and NPCImage which stores information about the NPC associated with the building. The NPCDialog which is shown is chosen at random.