### PR TITLE
Bank

### DIFF
--- a/scripts/buildings/bank.gd
+++ b/scripts/buildings/bank.gd
@@ -12,7 +12,7 @@ func get_scale_factor(bd_print: BuildingBlueprint) -> float:
 		func(acc, building): 
 			# I'm assuming equality works here, possibly change later
 			var matches_type = building.blueprint == bd_print
-			acc + 1 if matches_type else acc
+			return acc + 1 if matches_type else acc
 	, 0)
 	return pow(adjust_factor, match_cnt)
 

--- a/scripts/buildings/bank.gd
+++ b/scripts/buildings/bank.gd
@@ -4,7 +4,8 @@ extends Node
 func get_bonus() -> BuildingBonus:
 	return BuildingBonus.new()
 
-# Count the number of adjacent buildings matching the type of the blueprint parameter
+# Count the number of adjacent buildings matching the type of the blueprint parameter 
+# and calculate the appropriate modifier
 func get_scale_factor(bd_print: BuildingBlueprint) -> float:
 	var adjust_factor: float = 0.75
 	var match_cnt = get_parent().get_adjacent_buildings().reduce(

--- a/scripts/buildings/bank.gd
+++ b/scripts/buildings/bank.gd
@@ -1,0 +1,19 @@
+class_name Bank
+extends Node
+
+func get_bonus() -> BuildingBonus:
+	return BuildingBonus.new()
+
+# Count the number of adjacent buildings matching the type of the blueprint parameter
+func get_scale_factor(bd_print: BuildingBlueprint) -> float:
+	var adjust_factor: float = 0.75
+	var match_cnt = get_parent().get_adjacent_buildings().reduce(
+		func(acc, building): 
+			# I'm assuming equality works here, possibly change later
+			var matches_type = building.blueprint == bd_print
+			acc + 1 if matches_type else acc
+	, 0)
+	return pow(adjust_factor, match_cnt)
+
+func get_info_text() -> String:
+	return "For every building adjacent, buildings of that type are 25% cheaper! (stacks)"

--- a/scripts/buildings/nuclear_reactor.gd
+++ b/scripts/buildings/nuclear_reactor.gd
@@ -1,4 +1,5 @@
-class_name NuclearReactor extends Node
+class_name NuclearReactor
+extends Node
 
 ## Give CPD equal to the sum of each neighbor's CPD times 4
 func get_bonus() -> BuildingBonus:

--- a/scripts/environment/skyview_controls.gd
+++ b/scripts/environment/skyview_controls.gd
@@ -47,7 +47,7 @@ func end_day() -> void:
 func spawn_balloon(price: int, variation: BuildingVariation) -> Balloon:
 	var balloon: Balloon = spawn_balloon_at(
 		Vector2(randf_range(-180, 180), randf_range(-350, -200)))
-	balloon.init_from_blueprint_variation(variation)
+	balloon.init_from_blueprint_variation(variation, _building_grid)
 	balloon.on_click.connect(func(): balloon_dialogue(balloon))
 	balloon.price = price
 	balloon.grid = _building_grid
@@ -57,7 +57,7 @@ func spawn_balloon(price: int, variation: BuildingVariation) -> Balloon:
 func spawn_random_balloon_at_cursor() -> Balloon:
 	var balloon = spawn_balloon_at(_moving_camera.get_global_mouse_position())
 	var variation: BuildingVariation = _test_variations[randi_range(0, len(_test_variations) - 1)]
-	balloon.init_from_blueprint_variation(variation)
+	balloon.init_from_blueprint_variation(variation, _building_grid)
 	balloon.price = 0
 	balloon.grid = _building_grid
 	return balloon
@@ -65,11 +65,11 @@ func spawn_random_balloon_at_cursor() -> Balloon:
 ## Spawn a balloon (with no initialized variation) in a random position.
 func spawn_balloon_at(pos: Vector2) -> Balloon:
 	var balloon: Balloon = _balloon.instantiate()
+	balloon.grid = _building_grid
 	balloon.position = pos
 	balloon.on_click.connect(func(): balloon_dialogue(balloon))
 	balloon.moving_camera = _moving_camera
 	add_child(balloon)
-	balloon.grid = _building_grid
 	return balloon
 
 ## Spawn a dialogue box (called when clicking on a balloon).

--- a/scripts/environment/skyview_controls.gd
+++ b/scripts/environment/skyview_controls.gd
@@ -50,6 +50,7 @@ func spawn_balloon(price: int, variation: BuildingVariation) -> Balloon:
 	balloon.init_from_blueprint_variation(variation)
 	balloon.on_click.connect(func(): balloon_dialogue(balloon))
 	balloon.price = price
+	balloon.grid = _building_grid
 	return balloon
 
 ## Spawn a balloon at the cursor position.
@@ -58,6 +59,7 @@ func spawn_random_balloon_at_cursor() -> Balloon:
 	var variation: BuildingVariation = _test_variations[randi_range(0, len(_test_variations) - 1)]
 	balloon.init_from_blueprint_variation(variation)
 	balloon.price = 0
+	balloon.grid = _building_grid
 	return balloon
 
 ## Spawn a balloon (with no initialized variation) in a random position.
@@ -67,6 +69,7 @@ func spawn_balloon_at(pos: Vector2) -> Balloon:
 	balloon.on_click.connect(func(): balloon_dialogue(balloon))
 	balloon.moving_camera = _moving_camera
 	add_child(balloon)
+	balloon.grid = _building_grid
 	return balloon
 
 ## Spawn a dialogue box (called when clicking on a balloon).

--- a/scripts/systems/shop/balloon.gd
+++ b/scripts/systems/shop/balloon.gd
@@ -45,7 +45,7 @@ func _ready() -> void:
 
 ## Initialize this balloon from a blueprint variation, setting the texture and
 ## other data.
-func init_from_blueprint_variation(variation: BuildingVariation) -> void:
+func init_from_blueprint_variation(variation: BuildingVariation, grid: BuildingGrid) -> void:
 	self.blueprint = variation.blueprint
 	self.variation = variation
 	self.lifetime = blueprint.balloon_lifetime

--- a/scripts/systems/shop/balloon.gd
+++ b/scripts/systems/shop/balloon.gd
@@ -16,10 +16,21 @@ var price: int
 ## The number of days left in this balloon's lifetime.
 var lifetime: int
 
+# Reference to the grid containing the building
+var grid: BuildingGrid
+
 ## The area of this balloon that can be clicked.
 @onready var click_area: Area2D = $HitboxArea
 
 @onready var sprite: Sprite2D = $BuildingSprite
+
+# Get the price after applying modifiers (Right now just the bank)
+func adjusted_price() -> int:
+	var scale:float = 1
+	for building in grid.buildings:
+		if building.bonus is Bank:
+			scale *= building.bonus.get_scale_factor(blueprint)
+	return price * scale
 
 func _ready() -> void:
 	click_area.input_event.connect(click_input)

--- a/scripts/ui/gameplay/npc_dialogue_box.gd
+++ b/scripts/ui/gameplay/npc_dialogue_box.gd
@@ -26,7 +26,7 @@ var label_setting_red: LabelSettings
 func init_from_balloon(balloon, canAfford):
 	self.balloon = balloon
 	self.variation = balloon.variation
-	self.price = balloon.price
+	self.price = balloon.adjusted_price()
 	if !canAfford:
 		yes_button.hide()
 	update_text()


### PR DESCRIPTION
Okay so this is how the bank implementation works. The bank building bonus contains a function that takes a blueprint and returns the appropriate power of 0.75 (the number of adjacent buildings to the bank matching the blueprint) it just uses == on the blueprints, hope that works

The balloon class is changed, there is now a field which is a reference to a grid, so now the constructors have a parameter for that (I changed the 2 calls in the code base). It also now has a method which gives the modified price, just by looping over the grid, and when it finds a bank it calls the bonus' count_match method and returns the price field times the appropriate exponent of the modifier. 

So we gotta use that adjusted price, not the balloon's price field which is the price before modifiers. I changed the box constructor to reflect this but in the future when balloon price is needed this should be kept in mind. Maybe it would be good to change the price field to be named _price to make this more clear.

